### PR TITLE
fix: Perform sorting and limits in the queries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,13 @@ dependencies = [
 
 [project.optional-dependencies]
 faiss = [
-  "omop-emb[faiss]>=0.3.2",
+  "omop-emb[faiss]>=0.3.3",
 ]
 pgvector = [
-  "omop-emb[pgvector]>=0.3.2",
+  "omop-emb[pgvector]>=0.3.3",
 ]
 emb = [
-  "omop-emb[all]>=0.3.2"
+  "omop-emb[all]>=0.3.3"
 ]
 
 [dependency-groups]
@@ -62,7 +62,7 @@ dev = [
     "pytest-cov>=7.0.0",
     "rich>=14.2.0",
     "ruff>=0.14.10",
-    "omop-emb[all]>=0.3.2",
+    "omop-emb[all]>=0.3.3",
     "mkdocs<2.0",
     "mkdocs-material",
     "mkdocstrings[python]",

--- a/src/omop_graph/extensions/emb.py
+++ b/src/omop_graph/extensions/emb.py
@@ -112,7 +112,7 @@ def semantic_similarity(
         return None
     
     concept_ids = tuple(dict.fromkeys(sc.concept_id for sc in standard_concepts))
-    concept_filter = SearchConstraintConcept(concept_ids=concept_ids)
+    concept_filter = SearchConstraintConcept(concept_ids=concept_ids, limit=len(concept_ids))
 
     with kg.session_factory() as session:
         similarity_scores_tuple_of_dicts = get_neareast_concepts(
@@ -123,7 +123,6 @@ def semantic_similarity(
             concept_filter=concept_filter,
             metric_type=metric_type,
             index_type=index_type,
-            k=len(concept_ids)
         )
 
         if not similarity_scores_tuple_of_dicts:
@@ -194,7 +193,6 @@ def get_neareast_concepts(
     concept_filter: Optional[SearchConstraintConcept],
     metric_type: Optional[EmbeddingMetricType],
     index_type: Optional[EmbeddingIndexType],
-    k: int = 10
 ) -> Optional[Tuple[Mapping[int, float], ...]]:
     """
     RAG retrieval for concept similarity scores. The text_embedding is used to retrieve the nearest concepts from the database
@@ -211,13 +209,11 @@ def get_neareast_concepts(
     text_embedding : Optional[np.ndarray]
         The embedding vector to search with. Expected shape is (q, dimension) where q is the number of query vectors and dimension is the size of the embedding space for the model. If None, retrieval will not be attempted.
     concept_filter : Optional[EmbeddingConceptFilter], optional
-        A filter to specify which concepts to consider as potential nearest neighbors.
+        A filter to specify which concepts to consider as potential nearest neighbors. Also limits the number of neighbors returned (K). If None, internal defaults are used to limit the number of neighbours.
     index_type : IndexType
         The type of vector index used to store the embeddings.
     metric_type : MetricType
         The similarity or distance metric to use for nearest neighbor search. This must be compatible with the index type used by the database.
-    k : int, optional
-        K nearest neighbors to return for each query vector. Default is 10.
 
     Returns
     -------
@@ -270,21 +266,13 @@ def get_neareast_concepts(
         query_embedding=text_embedding,
         concept_filter=concept_filter,  # type: ignore
         metric_type=resolved_metric_type,
-        k=k
     )
 
     if similarity_scores_tuple is None:
         logger.info("No similarity scores retrieved from embedding interface.")
         return None
     
-    assert len(similarity_scores_tuple) == text_embedding.shape[0], (
-        f"Expected similarity scores for {text_embedding.shape[0]} query embeddings, "
-        f"but got {len(similarity_scores_tuple)}."
-    )
     assert all(isinstance(d, dict) for d in similarity_scores_tuple), (
         "Expected each item in similarity_scores_tuple to be a dictionary mapping concept IDs to scores."
-    )
-    assert all(len(d) <= k for d in similarity_scores_tuple), (
-        f"Expected at most {k} nearest neighbors per query embedding, but found a dictionary with {max(len(d) for d in similarity_scores_tuple)} entries."
     )
     return similarity_scores_tuple

--- a/src/omop_graph/graph/constraints.py
+++ b/src/omop_graph/graph/constraints.py
@@ -29,11 +29,14 @@ class SearchConstraintConcept:
     require_standard : bool, optional
         If True, restricts results to standard ('S') or classification ('C') concepts.
         Default is False.
+    limit: int, optional
+        If set, limits the number of results returned by the query.
     """
     concept_ids: Optional[Tuple[int, ...]] = field(default=None)
     domains: Optional[Tuple[str, ...]] = field(default=None)
     vocabularies: Optional[Tuple[str, ...]] = field(default=None)
     require_standard: bool = False
+    limit: Optional[int] = None
 
     def apply(self, query: Select) -> Select:
         """
@@ -62,4 +65,4 @@ class SearchConstraintConcept:
             # Filters for 'S' (Standard) or 'C' (Classification)
             query = query.where(Concept.standard_concept.in_(["S", "C"]))
             
-        return query
+        return query.limit(self.limit)

--- a/src/omop_graph/graph/kg.py
+++ b/src/omop_graph/graph/kg.py
@@ -41,7 +41,6 @@ from .nodes import (
     AncestorMatch,
     ConceptView,
     LabelMatch,
-    LabelMatchGroupView,
     LabelMatchKind,
 )
 from .queries import (
@@ -176,7 +175,7 @@ class KnowledgeGraph(GraphBackend):
         return ConceptView.from_row(row)
 
     @lru_cache(maxsize=200_000)
-    def concept_views(self, concept_ids: tuple[int, ...]) -> tuple[ConceptView, ...]:
+    def concept_views(self, concept_ids: tuple[int, ...], sort: bool = True) -> tuple[ConceptView, ...]:
         """
         Retrieve multiple concept views in a batch.
 
@@ -193,7 +192,7 @@ class KnowledgeGraph(GraphBackend):
         with self.session_factory() as session:
             concept_views = tuple(
                 ConceptView.from_row(row)
-                for row in session.execute(q_concept_views(concept_ids))
+                for row in session.execute(q_concept_views(concept_ids, sort=sort))
             )
         return concept_views
 
@@ -230,7 +229,7 @@ class KnowledgeGraph(GraphBackend):
         synonym: bool = False,
         search_constraint: Optional[SearchConstraintConcept] = None,
         sort: bool = True
-    ) -> LabelMatchGroupView:
+    ) -> tuple[LabelMatch, ...]:
         """
         Resolve a label to concept_id(s).
         
@@ -248,7 +247,7 @@ class KnowledgeGraph(GraphBackend):
         """
         input_label = self._normalise_label(label)
         if not input_label:
-            return LabelMatchGroupView.from_matches(())
+            return ()
 
         if match_kind == LabelMatchKind.EXACT:
             fn = q_concept_name_match
@@ -259,7 +258,12 @@ class KnowledgeGraph(GraphBackend):
         else:
             raise ValueError(f"Unsupported search mode: {match_kind}")
         try:
-            cn = fn(input_label, search_constraint=search_constraint, synonym=synonym)
+            cn = fn(
+                input_label,
+                search_constraint=search_constraint,
+                synonym=synonym,
+                sort=sort,
+            )
         except FullTextError:
             if match_kind == LabelMatchKind.FTS:
                 logger.info(
@@ -268,7 +272,7 @@ class KnowledgeGraph(GraphBackend):
                     "fulltext install` and `omop-maint fulltext populate` to enable "
                     "this resolver."
                 )
-                return LabelMatchGroupView.from_matches(())
+                return ()
             raise
 
         with self.session_factory() as session:
@@ -283,10 +287,7 @@ class KnowledgeGraph(GraphBackend):
                 )
                 for cid, name, is_standard, is_active in session.execute(cn)
             )
-
-        if sort:
-            matches = sorted(matches)
-        return LabelMatchGroupView.from_matches(matches)
+        return matches
 
 
     @lru_cache(maxsize=200_000)

--- a/src/omop_graph/graph/nodes.py
+++ b/src/omop_graph/graph/nodes.py
@@ -233,40 +233,6 @@ class LabelMatch:
         </div>
         """
 
-    def __lt__(self, other: LabelMatch) -> bool:
-        """
-        Compare two LabelMatches for sorting.
-        Delegates to `label_match_rank`.
-        """
-        return label_match_rank(self) < label_match_rank(other)
-
-
-def label_match_rank(m: LabelMatch) -> Tuple[bool, bool, int, int]:
-    """
-    Calculate a ranking key for a label match. Lower is better.
-
-    Priority:
-    1. Standard Concept (True < False)
-    2. Active Concept (True < False)
-    3. Match Kind (Direct < Synonym < Fulltext < Embedding)
-    4. Label Length (Shorter < Longer)
-
-    Parameters
-    ----------
-    m : LabelMatch
-        The match to rank.
-
-    Returns
-    -------
-    tuple
-        A tuple of comparable values.
-    """
-    return (
-        not m.is_standard,  # Prefer standard (True -> False/0)
-        not m.is_active,  # Prefer active (True -> False/0)
-        m.match_kind.value,  # Prefer lower enum value (Direct=1)
-        len(m.matched_label),  # Prefer shorter matches
-    )
 
 
 @dataclass(frozen=True)
@@ -290,7 +256,11 @@ class LabelMatchGroupView:
         """
         Construct a group view from a flat iterable of matches.
 
-        Matches are grouped by Concept ID and then sorted by quality within each group.
+        Matches are grouped by Concept ID.
+
+        Notes
+        -----
+        This could also be performed in SQL during the query phase.
 
         Parameters
         ----------
@@ -306,11 +276,8 @@ class LabelMatchGroupView:
         for m in matches:
             grouped[m.concept_id].append(m)
 
-        # Sort each group by match quality
-        groups_sorted = {
-            cid: tuple(sorted(ms)) for cid, ms in grouped.items()
-        }
-        return cls(groups=groups_sorted)
+        grouped_tuple = {cid: tuple(ms) for cid, ms in grouped.items()}
+        return cls(groups=grouped_tuple)
 
     def __iter__(self):
         """Iterate over all matches flattened."""

--- a/src/omop_graph/graph/queries.py
+++ b/src/omop_graph/graph/queries.py
@@ -38,6 +38,41 @@ from ..extensions.omop_alchemy import RelationshipClass, RelationshipMapping, Cl
 from .constraints import SearchConstraintConcept
 
 
+def _concept_match_order_terms(name_expr, rank_expr=None):
+    """
+    Build a stable ordering for concept label matches.
+
+    Ordering logic:
+    - Basic ordering
+        1. Standard concepts first (standard_concept in ["S", "C"])
+        2. Active concepts first (invalid_reason not in ["D", "U"])
+        3. Shorter label length first (LENGTH(name))
+        4. Lower concept_id as final tie-breaker
+    - If rank_expr is provided (e.g. FTS rank):
+        0. rank_expr (e.g. FTS: Highest full-text relevance score (ts_rank))
+
+    This ensures that, for all search types, the most relevant, standard, active, and concise concepts are ranked first.
+    """
+    terms = []
+    if rank_expr is not None:
+        terms.append(rank_expr.desc())
+    terms.extend(
+        (
+            case(
+                (Concept.standard_concept.in_(["S", "C"]), literal(0)),
+                else_=literal(1),
+            ),
+            case(
+                (Concept.invalid_reason.in_(["D", "U"]), literal(1)),
+                else_=literal(0),
+            ),
+            func.length(name_expr),
+            Concept.concept_id,
+        )
+    )
+    return tuple(terms)
+
+
 def q_concept_view(concept_id: int) -> Select:
     """
     Query for a single concept by its ID.
@@ -66,37 +101,38 @@ def q_concept_view(concept_id: int) -> Select:
     ).where(Concept.concept_id == concept_id)
 
 
-def q_concept_views(concept_ids: Tuple[int, ...]) -> Select:
+def q_concept_views(concept_ids: Tuple[int, ...], sort: bool = True) -> Select:
     """
-    Query for multiple concepts by their IDs, preserving the input order.
+    Query for multiple concepts by their IDs.
 
     Parameters
     ----------
     concept_ids : tuple[int, ...]
         A tuple of OMOP Concept IDs.
+    sort : bool, default True
+        If True, preserve the input order using a CASE statement.
+        If False, do not add an ORDER BY clause (DB returns arbitrary order).
 
     Returns
     -------
     Select
-        A statement selecting standard concept columns ordered by the input list.
+        A statement selecting standard concept columns, optionally ordered by input list.
     """
-    order_map = {cid: index for index, cid in enumerate(concept_ids)}
-    return (
-        select(
-            Concept.concept_id,
-            Concept.concept_name,
-            Concept.concept_code,
-            Concept.vocabulary_id,
-            Concept.domain_id,
-            Concept.concept_class_id,
-            Concept.standard_concept,
-            Concept.valid_start_date,
-            Concept.valid_end_date,
-            Concept.invalid_reason,
-        )
-        .where(Concept.concept_id.in_(concept_ids))
-        .order_by(case(order_map, value=Concept.concept_id))
-    )
+    stmt = select(
+        Concept.concept_id,
+        Concept.concept_name,
+        Concept.concept_code,
+        Concept.vocabulary_id,
+        Concept.domain_id,
+        Concept.concept_class_id,
+        Concept.standard_concept,
+        Concept.valid_start_date,
+        Concept.valid_end_date,
+        Concept.invalid_reason,
+    ).where(Concept.concept_id.in_(concept_ids))
+    if sort:
+        stmt = stmt.order_by(*_concept_match_order_terms(Concept.concept_name))
+    return stmt
 
 
 def q_concept_id_by_code(vocabulary_id: str, concept_code: str) -> Select:
@@ -175,7 +211,8 @@ def q_concept_synonym() -> Select:
 def q_concept_name_match(
     name: str, 
     search_constraint: Optional[SearchConstraintConcept] = None,
-    synonym: bool = False
+    synonym: bool = False,
+    sort: bool = True,
 ) -> Select:
     """
     Query for exact case-insensitive matches on concept names.
@@ -194,13 +231,15 @@ def q_concept_name_match(
     Select
         The query statement.
     """
+    name_expr = Concept_Synonym.concept_synonym_name if synonym else Concept.concept_name
+
     if synonym:
         base_stmt = q_concept_synonym().where(
-            func.lower(Concept_Synonym.concept_synonym_name) == func.lower(name)
+            func.lower(name_expr) == func.lower(name)
         )
     else:
         base_stmt = q_concept_name().where(
-            func.lower(Concept.concept_name) == func.lower(name)
+            func.lower(name_expr) == func.lower(name)
         )
     if search_constraint:
         if not isinstance(search_constraint, SearchConstraintConcept):
@@ -208,13 +247,16 @@ def q_concept_name_match(
                 "search_constraint must be an instance of SearchConstraintConcept"
             )
         base_stmt = search_constraint.apply(base_stmt)
+    if sort:
+        base_stmt = base_stmt.order_by(*_concept_match_order_terms(name_expr))
     return base_stmt
 
 
 def q_concept_name_ilike(
     term: str, 
     search_constraint: Optional[SearchConstraintConcept] = None,
-    synonym: bool = False
+    synonym: bool = False,
+    sort: bool = True,
 ) -> Select:
     """
     Query for partial matches on concept names using ILIKE.
@@ -233,13 +275,15 @@ def q_concept_name_ilike(
     Select
         The query statement.
     """
+    name_expr = Concept_Synonym.concept_synonym_name if synonym else Concept.concept_name
+
     if synonym:
         base_stmt = q_concept_synonym().where(
-            Concept_Synonym.concept_synonym_name.ilike(f"%{term}%")
+            name_expr.ilike(f"%{term}%")
         )
     else:
         base_stmt = q_concept_name().where(
-            Concept.concept_name.ilike(f"%{term}%")
+            name_expr.ilike(f"%{term}%")
         )
     if search_constraint:
         if not isinstance(search_constraint, SearchConstraintConcept):
@@ -247,13 +291,16 @@ def q_concept_name_ilike(
                 "search_constraint must be an instance of SearchConstraintConcept"
             )
         base_stmt = search_constraint.apply(base_stmt)
+    if sort:
+        base_stmt = base_stmt.order_by(*_concept_match_order_terms(name_expr))
     return base_stmt
 
 
 def q_concept_name_fulltext(
     term: str, 
     search_constraint: Optional['SearchConstraintConcept'] = None,
-    synonym: bool = False
+    synonym: bool = False,
+    sort: bool = True,
 ) -> Select:
     """
     Query for concept names using PostgreSQL full-text search via optional
@@ -275,6 +322,8 @@ def q_concept_name_fulltext(
         Whether to search in synonyms instead of concept names.
 
     """
+    name_expr = Concept_Synonym.concept_synonym_name if synonym else Concept.concept_name
+
     if synonym:
         vector = Concept_Synonym.__table__.c.get(CONCEPT_SYNONYM_NAME_TSVECTOR_COLUMN)
         stmt = q_concept_synonym()
@@ -292,13 +341,15 @@ def q_concept_name_fulltext(
         
     query = func.plainto_tsquery("english", term)
     
-    stmt = (stmt
-        .where(vector.op("@@")(query))  # Hits the GIN index instantly
-        .order_by(func.ts_rank(vector, query).desc())
-    )
+    stmt = stmt.where(vector.op("@@")(query))  # Hits the GIN index instantly
 
     if search_constraint:
         stmt = search_constraint.apply(stmt)
+
+    if sort:
+        stmt = stmt.order_by(
+            *_concept_match_order_terms(name_expr, rank_expr=func.ts_rank(vector, query))
+        )
 
     return stmt
 

--- a/src/omop_graph/reasoning/resolvers/resolvers.py
+++ b/src/omop_graph/reasoning/resolvers/resolvers.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from omop_graph.graph.constraints import SearchConstraintConcept
 from omop_graph.graph.kg import KnowledgeGraph
-from omop_graph.graph.nodes import LabelMatch, LabelMatchKind, LabelMatchGroupView
+from omop_graph.graph.nodes import LabelMatch, LabelMatchKind
 from omop_graph.extensions.emb import (
     HAS_OMOP_EMB,
     EmbeddingIndexType,
@@ -252,7 +252,8 @@ class EmbeddingResolver(CandidateResolver):
             assert len(matches) == 1, "Expected get_neareast_concepts to return a single dictionary given the text_embedding shape (1, embedding_dim)."
             matches = matches[0]  # Unpack the single dictionary from the tuple
             concept_views = kg.concept_views(
-                concept_ids=tuple(matches.keys())
+                concept_ids=tuple(matches.keys()),
+                sort=sort
             )
             label_matches = tuple(
                 LabelMatch(
@@ -265,10 +266,7 @@ class EmbeddingResolver(CandidateResolver):
                 )
                 for cv in concept_views
             )
-
-            if sort:
-                label_matches = sorted(label_matches)
-            return tuple(LabelMatchGroupView.from_matches(label_matches))
+            return label_matches
 
 
 # Default sequence of resolvers to be used in a pipeline

--- a/src/omop_graph/reasoning/resolvers/resolvers.py
+++ b/src/omop_graph/reasoning/resolvers/resolvers.py
@@ -135,9 +135,8 @@ class CandidateResolver:
         text : str
             The input text.
         constraints : SearchConstraintConcept, optional
-            Filters.
-        limit : int, optional
-            Max number of hits to return.
+            Filters for concepts to consider in the search. Also limits the number of candidates returned
+            using the `limit` field. 
 
         Returns
         -------

--- a/src/omop_graph/reasoning/resolvers/resolvers.py
+++ b/src/omop_graph/reasoning/resolvers/resolvers.py
@@ -123,7 +123,6 @@ class CandidateResolver:
         kg: KnowledgeGraph,
         text: str,
         constraints: Optional[SearchConstraintConcept] = None,
-        limit: Optional[int] = None,
         **kwargs
     ) -> Iterable[CandidateHit]:
         """
@@ -155,7 +154,7 @@ class CandidateResolver:
             )
             for m in matches
         ]
-        return hits[:limit] if limit else hits
+        return hits
 
 
 class ExactLabelResolver(CandidateResolver):

--- a/tests/test_resolvers_mock.py
+++ b/tests/test_resolvers_mock.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Dict, List, cast
 
 from omop_graph.graph.kg import KnowledgeGraph
-from omop_graph.graph.nodes import LabelMatch, LabelMatchGroupView, LabelMatchKind
+from omop_graph.graph.nodes import LabelMatch, LabelMatchKind
 from omop_graph.reasoning.resolvers.resolver_pipeline import ResolverPipeline
 from omop_graph.reasoning.resolvers.resolvers import (
     ExactLabelResolver,
@@ -27,7 +27,7 @@ class _KG:
     def concept_lookup(self, label: str, match_kind: LabelMatchKind, synonym: bool = False, search_constraint=None, sort: bool = False):
         key = _key(match_kind, synonym)
         concept_ids = self.case.hits.get(key, [])
-        matches = tuple(
+        return tuple(
             LabelMatch(
                 input_label=label,
                 matched_label=f"concept-{cid}",
@@ -38,7 +38,6 @@ class _KG:
             )
             for cid in concept_ids
         )
-        return LabelMatchGroupView.from_matches(matches)
 
 
 def _key(match_kind: LabelMatchKind, synonym: bool) -> str:


### PR DESCRIPTION
Instead of having sorting and limits in the respective calling functions, expose it directly through the queries.

This commits also removes the usage of `LabelMatchGroupView` for grouped queries and instead leaves it as an interface for debugging as the majority of functions do not make use of the functionality regardless.