### PR TITLE
fix: Correct on-demand embedding calculation

### DIFF
--- a/docs/graph/kg.md
+++ b/docs/graph/kg.md
@@ -51,3 +51,72 @@ print(f"ID: {concept.concept_id}, Name: {concept.matched_label}")
 parents = kg.parents(concept.concept_id)
 print(f"Parent IDs: {parents}")
 ```
+
+---
+
+### Embedding Configuration
+
+To enable semantic similarity and RAG-based retrieval, pass a `KnowledgeGraphEmbeddingConfiguration` when initialising the graph.
+This requires the optional `omop-emb` package — see the [installation guide](../usage/installation.md#embedding-rag).
+
+#### Read-only (pre-computed embeddings already in the DB)
+
+Use this when embeddings have already been indexed and you only need retrieval:
+
+```python
+from omop_graph.graph.kg import KnowledgeGraph, KnowledgeGraphEmbeddingConfiguration
+from omop_emb import BackendType, ProviderType
+
+emb_config = KnowledgeGraphEmbeddingConfiguration(
+    backend_type=BackendType.FAISS,
+    provider_type=ProviderType.OLLAMA,
+    canonical_model_name="text-embedding-3-small:0.6b",
+    base_storage_dir="/data/embeddings",
+)
+kg = KnowledgeGraph(SessionLocal, emb_config=emb_config)
+```
+
+#### Write-capable (generate and store embeddings at runtime)
+
+Provide an `EmbeddingClient` to enable both reading and writing embeddings:
+
+```python
+from omop_emb import EmbeddingClient
+from omop_emb import BackendType, ProviderType
+
+client = EmbeddingClient(...)  # configured for your provider
+
+emb_config = KnowledgeGraphEmbeddingConfiguration(
+    backend_type=BackendType.FAISS,
+    base_storage_dir="/data/embeddings",
+    client=client,
+)
+kg = KnowledgeGraph(SessionLocal, emb_config=emb_config)
+```
+The `provider_type` will be automatically determined from the `client`.
+
+#### Fallback embedding calculation
+
+When some concepts in the OMOP DB have not been pre-indexed, similarity scoring will silently skip them.
+Setting `compute_missing_embeddings=True` instructs the graph to compute and persist embeddings
+for any missing concepts on-the-fly during a similarity call.
+
+!!! warning
+    This flag has no effect unless a write-capable interface is configured (i.e. a `client` is provided).
+    Without a `client`, the graph holds a read-only interface and cannot write back to the embedding store.
+
+```python
+emb_config = KnowledgeGraphEmbeddingConfiguration(
+    backend_type="faiss",
+    base_storage_dir="/data/embeddings",
+    client=client,
+    compute_missing_embeddings=True,  # compute embeddings for concepts not yet in the store
+)
+kg = KnowledgeGraph(SessionLocal, emb_config=emb_config)
+```
+
+| `compute_missing_embeddings` | `client` present | Behaviour when concepts are missing |
+|---|---|---|
+| `False` (default) | any | Log at INFO and skip missing concepts in scoring |
+| `True` | no | Log warning that computation is not possible; skip missing concepts |
+| `True` | yes | Compute embeddings, persist to DB, then score |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,13 @@ dependencies = [
 
 [project.optional-dependencies]
 faiss = [
-  "omop-emb[faiss]>=0.4.0",
+  "omop-emb[faiss]==0.4.0",
 ]
 pgvector = [
-  "omop-emb[pgvector]>=0.4.0",
+  "omop-emb[pgvector]==0.4.0",
 ]
 emb = [
-  "omop-emb[all]>=0.4.0"
+  "omop-emb[all]==0.4.0"
 ]
 
 [dependency-groups]
@@ -62,7 +62,7 @@ dev = [
     "pytest-cov>=7.0.0",
     "rich>=14.2.0",
     "ruff>=0.14.10",
-    "omop-emb[all]>=0.4.0",
+    "omop-emb[all]==0.4.0",
     "mkdocs<2.0",
     "mkdocs-material",
     "mkdocstrings[python]",

--- a/src/omop_graph/extensions/emb.py
+++ b/src/omop_graph/extensions/emb.py
@@ -143,10 +143,60 @@ def semantic_similarity(
         logger.info("Embedding reader interface not found in KG. Skipping similarity calculation.")
         return None
     
+    if index_type is None:
+        logger.info("Index type is required for similarity calculation but not provided. Skipping similarity calculation.")
+        return None
+    
     concept_ids = tuple(dict.fromkeys(sc.concept_id for sc in standard_concepts))
     concept_filter = SearchConstraintConcept(concept_ids=concept_ids, limit=len(concept_ids))
 
     with kg.session_factory() as session:
+        missing_sc_embeddings = embedding_reader.get_concepts_without_embedding(
+            session=session,
+            concept_filter=concept_filter,  # type: ignore
+            index_type=index_type,
+        )
+
+        if missing_sc_embeddings:
+            if kg.compute_missing_embeddings:
+                logger.debug(f"Concepts missing embeddings: {missing_sc_embeddings}. Computing missing embeddings on-the-fly.")
+                embedding_writer = get_embedding_writer_interface(kg)
+                if (
+                    embedding_writer is not None and
+                    text_embedding_model is not None and
+                    text_embedding is not None
+                ):
+
+                    missing_concept_ids = tuple(missing_sc_embeddings.keys())
+                    missing_concept_texts = tuple(missing_sc_embeddings.values())
+                    calculated_embeddings = embedding_writer.embed_texts(texts=missing_concept_texts)
+                    embedding_writer.add_to_db(
+                        embeddings=calculated_embeddings,
+                        concept_ids=missing_concept_ids,
+                        session=session,
+                        index_type=index_type,
+                    )
+                    logger.debug(f"Computed and stored embeddings for missing concepts: {missing_concept_ids}")
+                else:
+                    param_dict = {
+                        "text_embedding_model": text_embedding_model,
+                        "embedding_writer": embedding_writer,
+                        "text_embedding": text_embedding,
+                        "index_type": index_type
+                    }
+                    none_params = [k for k, v in param_dict.items() if v is None]
+                    logger.info(
+                        f"Cannot compute missing embeddings due to missing parameters: {none_params}\n"
+                        "Ensure the KG was initialised with a write-capable client to enable on-the-fly embedding computation.\n"
+                        f"Expect missing embedding scores for concepts: {missing_sc_embeddings}"
+                    )
+            else:
+                logger.info(
+                    f"Concepts missing embeddings: {missing_sc_embeddings}.\n"
+                    "compute_missing_embeddings is disabled; these concepts will be skipped in similarity scoring.\n"
+                    "Expect missing embedding scores for these concepts in the results."
+                )
+
         similarity_scores_tuple_of_dicts = get_neareast_concepts(
             session=session,
             kg=kg,
@@ -156,66 +206,8 @@ def semantic_similarity(
             metric_type=metric_type,
             index_type=index_type,
         )
-
-        if not similarity_scores_tuple_of_dicts:
-            # Fallback logic if database retrieval fails
-            embedding_writer = get_embedding_writer_interface(kg)
-            
-            if (text_embedding_model is not None and
-                embedding_writer is not None and
-                text_embedding is not None and
-                index_type is not None
-            ):
-                logger.debug("Falling back to embedding client for similarity scores.")
-
-                if text_embedding_model != embedding_writer.canonical_model_name:
-                    raise ValueError(f"Text embedding model '{text_embedding_model}' does not match the model registered in the embedding writer interface ('{embedding_writer.canonical_model_name}'). Ensure that the text_embedding was generated using the same model as the one registered in the embedding interface for accurate similarity calculation.")
-
-                # Validate types at runtime since static checks won't catch this without the lib
-                if not isinstance(text_embedding, np.ndarray):
-                    raise TypeError("text_embedding must be a numpy array.")
-                
-                # Fetch missing embeddings and update DB
-                missing_sc_embeddings = embedding_writer.get_concepts_without_embedding(
-                    session=session,
-                    concept_filter=concept_filter,  # type: ignore
-                    index_type=index_type,
-                )
-
-                if missing_sc_embeddings:
-                    missing_concept_ids = tuple(missing_sc_embeddings.keys())
-                    standard_concept_embeddings = embedding_writer.embed_texts(
-                        texts=tuple(missing_sc_embeddings.values()),
-                    )
-
-                    embedding_writer.add_to_db(
-                        embeddings=standard_concept_embeddings,
-                        concept_ids=missing_concept_ids,
-                        session=session,
-                        index_type=index_type,
-                    )
-
-                # Re-attempt retrieval after update
-                similarity_scores_tuple_of_dicts = get_neareast_concepts(
-                    session=session,
-                    kg=kg,
-                    text_embedding_model=text_embedding_model,
-                    text_embedding=text_embedding,
-                    concept_filter=concept_filter,
-                    metric_type=metric_type,
-                    index_type=index_type
-                )
-            else:
-                param_dict = {
-                    "text_embedding_model": text_embedding_model,
-                    "embedding_writer": embedding_writer,
-                    "text_embedding": text_embedding,
-                    "index_type": index_type
-                }
-                none_params = [k for k, v in param_dict.items() if v is None]
-                logger.info(f"Fallback embedding calculation not possible for standard_concepts due to missing parameters: {none_params}")
-
-        return similarity_scores_tuple_of_dicts
+        
+    return similarity_scores_tuple_of_dicts
 
 def get_neareast_concepts(
     session: Session,

--- a/src/omop_graph/graph/kg.py
+++ b/src/omop_graph/graph/kg.py
@@ -89,6 +89,12 @@ class KnowledgeGraphEmbeddingConfiguration:
         The canonical model name to use for the embedding reader interface (e.g., 'text-embedding-3-small:0.6b').
         Required for read-only embedding interface to determine which embeddings to retrieve for concepts.
         Obtained from client if a client is provided, otherwise must be set explicitly for read-only use cases.
+    compute_missing_embeddings : bool
+        If True, the system will compute embeddings on-the-fly for any concept that is not yet present
+        in the embedding store, and persist those embeddings back to the DB before running similarity scoring.
+        **Requires a write-capable interface**: a ``client`` must be provided in this configuration; without it
+        the KG only holds a read-only interface, the flag has no effect, and missing concepts are silently skipped.
+        Defaults to ``False`` so that unexpected writes do not occur when only a read-only configuration is given.
     """
 
     backend_type: Optional[EmbeddingBackendType] = None
@@ -96,6 +102,7 @@ class KnowledgeGraphEmbeddingConfiguration:
     client: Optional[EmbeddingClient] = None
     provider_type: Optional[EmbeddingProviderType] = None
     canonical_model_name: Optional[str] = None
+    compute_missing_embeddings: bool = field(default=False)
 
 class KnowledgeGraph(GraphBackend):
     """
@@ -179,7 +186,16 @@ class KnowledgeGraph(GraphBackend):
                 "Embedding functionality failed to initialize due to an import error in the optional embedding stack."
             )
             raise e
+        
+    @property
+    def embedding_configuration(self) -> Optional[KnowledgeGraphEmbeddingConfiguration]:
+        """Returns the current embedding configuration, if set."""
+        return self._emb_config
 
+    @property
+    def compute_missing_embeddings(self) -> bool:
+        """Indicates whether on-the-fly computation of missing concept embeddings is enabled."""
+        return self._emb_config.compute_missing_embeddings if self._emb_config else False
 
     @lru_cache(maxsize=200_000)
     def concept_view(self, concept_id: int) -> ConceptView:

--- a/tests/test_embedding_optional.py
+++ b/tests/test_embedding_optional.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import builtins
 import contextlib
+import logging
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import Mock
@@ -14,7 +15,7 @@ from sqlalchemy.orm import Session
 
 from omop_graph.extensions import emb as emb_ext
 from omop_graph.extensions.emb import MissingExtensionError
-from omop_graph.graph.kg import KnowledgeGraph
+from omop_graph.graph.kg import KnowledgeGraph, KnowledgeGraphEmbeddingConfiguration
 from omop_graph.graph.nodes import LabelMatchKind
 from omop_graph.graph.paths import StandardConcept
 
@@ -82,23 +83,15 @@ def test_knowledge_graph_emb_raises_missing_extension_error_when_omop_emb_unavai
         _ = kg.emb
 
 
-def test_semantic_similarity_fallback_uses_missing_ids_with_index_type(monkeypatch: pytest.MonkeyPatch):
-    """Validate the fallback embedding flow when initial nearest retrieval returns no results.
+def test_write_path_forwards_index_type_and_only_missing_ids(monkeypatch: pytest.MonkeyPatch):
+    """Verify the omop-emb write-path contracts when compute_missing_embeddings is True.
 
-    This test forces ``semantic_similarity`` into its fallback branch by mocking
-    ``get_neareast_concepts`` to return ``None`` on the first call and a valid
-    score mapping on the second call.
+    1. ``index_type`` is forwarded to ``get_concepts_without_embedding``.
+    2. ``add_to_db`` receives only the IDs reported as missing — not the full
+       candidate set passed to ``semantic_similarity``.
 
-    It verifies two regression-critical contract details:
-    1. ``index_type`` is forwarded to
-       ``EmbeddingInterface.get_concepts_without_embedding``.
-    2. ``EmbeddingInterface.add_to_db`` receives only the concept IDs returned
-       as missing by ``get_concepts_without_embedding`` (not the full candidate
-       concept set).
-
-    These assertions protect against interface drift with omop-emb where
-    ``index_type`` is required and concept IDs must align with the embeddings
-    being upserted.
+    Concept 3 ("gamma") is in ``standard_concepts`` but is NOT returned by
+    ``get_concepts_without_embedding``, so ``add_to_db`` must receive only (1, 2).
     """
     class FakeEmbeddingInterface:
         canonical_model_name = "test-model"
@@ -121,14 +114,15 @@ def test_semantic_similarity_fallback_uses_missing_ids_with_index_type(monkeypat
     emb_interface = FakeEmbeddingInterface()
 
     class FakeKG:
+        compute_missing_embeddings = True
+
         def session_factory(self):
             return contextlib.nullcontext(Mock(spec=Session))
 
+    # get_neareast_concepts is called once; return a proper tuple-of-dicts.
     def fake_nearest(*args, **kwargs):
         fake_nearest.calls += 1
-        if fake_nearest.calls == 1:
-            return None
-        return {1: 0.9, 2: 0.8}
+        return ({1: 0.9, 2: 0.8},)
 
     fake_nearest.calls = 0
 
@@ -178,8 +172,102 @@ def test_semantic_similarity_fallback_uses_missing_ids_with_index_type(monkeypat
     )
 
     assert result is not None
-    assert fake_nearest.calls == 2
+    assert fake_nearest.calls == 1
     assert emb_interface.last_missing_kwargs is not None
     assert emb_interface.last_missing_kwargs["index_type"] == "flat"
     assert emb_interface.last_add_kwargs is not None
     assert emb_interface.last_add_kwargs["concept_ids"] == (1, 2)
+
+
+# ── compute_missing_embeddings flag tests (using real KG + dummy CDM DB) ──
+
+def _make_standard_concept(concept_id: int, name: str) -> StandardConcept:
+    return StandardConcept(
+        concept_id=concept_id,
+        concept_name=name,
+        separation=0,
+        original_id=concept_id,
+        original_name=name,
+        matched_label=name,
+        match_kind=LabelMatchKind.EXACT,
+        synonym=False,
+    )
+
+
+def test_fallback_flag_true_logs_attempt_when_concepts_missing(
+    mock_cdm_kg: KnowledgeGraph,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With compute_missing_embeddings=True and missing concepts, the debug
+    log confirming an on-the-fly computation attempt must be emitted.
+
+    The test uses the real KG backed by the in-memory CDM DB. Because no real
+    embedding model is available, the embedding interfaces are mocked. The
+    assertion is on log output rather than on actual embedding computation.
+    """
+    mock_cdm_kg._emb_config = KnowledgeGraphEmbeddingConfiguration(
+        compute_missing_embeddings=True,
+    )
+
+    fake_reader = Mock()
+    # concept 196653 ("Malignant tumor of kidney") exists in the dummy CDM DB
+    fake_reader.get_concepts_without_embedding.return_value = {
+        196653: "Malignant tumor of kidney"
+    }
+
+    monkeypatch.setattr(emb_ext, "HAS_OMOP_EMB", True)
+    monkeypatch.setattr(emb_ext, "get_embedding_reader_interface", lambda _: fake_reader)
+    # No writer injected: simulates a read-only config with fallback flag set.
+    monkeypatch.setattr(emb_ext, "get_embedding_writer_interface", lambda _: None)
+    monkeypatch.setattr(emb_ext, "get_neareast_concepts", lambda **_: None)
+
+    with caplog.at_level(logging.DEBUG, logger="omop_graph.extensions.emb"):
+        emb_ext.semantic_similarity(
+            kg=mock_cdm_kg,
+            standard_concepts=[_make_standard_concept(196653, "Malignant tumor of kidney")],
+            text_embedding=np.zeros((1, 3), dtype=np.float32),
+            text_embedding_model="test-model",
+            metric_type=cast(emb_ext.EmbeddingMetricType, "cosine"),
+            index_type=cast(emb_ext.EmbeddingIndexType, "flat"),
+        )
+
+    assert "Computing missing embeddings on-the-fly" in caplog.text
+
+
+def test_fallback_flag_false_logs_disabled_when_concepts_missing(
+    mock_cdm_kg: KnowledgeGraph,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With compute_missing_embeddings=False and missing concepts, the info
+    log stating that the flag is disabled must be emitted and no computation
+    must be attempted.
+
+    The test uses the real KG backed by the in-memory CDM DB.
+    """
+    mock_cdm_kg._emb_config = KnowledgeGraphEmbeddingConfiguration(
+        compute_missing_embeddings=False,
+    )
+
+    fake_reader = Mock()
+    fake_reader.get_concepts_without_embedding.return_value = {
+        196653: "Malignant tumor of kidney"
+    }
+
+    monkeypatch.setattr(emb_ext, "HAS_OMOP_EMB", True)
+    monkeypatch.setattr(emb_ext, "get_embedding_reader_interface", lambda _: fake_reader)
+    monkeypatch.setattr(emb_ext, "get_neareast_concepts", lambda **_: None)
+
+    with caplog.at_level(logging.INFO, logger="omop_graph.extensions.emb"):
+        emb_ext.semantic_similarity(
+            kg=mock_cdm_kg,
+            standard_concepts=[_make_standard_concept(196653, "Malignant tumor of kidney")],
+            text_embedding=np.zeros((1, 3), dtype=np.float32),
+            text_embedding_model="test-model",
+            metric_type=cast(emb_ext.EmbeddingMetricType, "cosine"),
+            index_type=cast(emb_ext.EmbeddingIndexType, "flat"),
+        )
+
+    assert "compute_missing_embeddings is disabled" in caplog.text
+    fake_reader.embed_texts.assert_not_called()


### PR DESCRIPTION
## Description
Previously, on-demand embedding calculation was implicit and triggered silently; partially pre-indexed concept sets also blocked fallback computation for the remaining missing concepts.

Closes #6 

## Changes
- Global flag (`compute_missing_embeddings` on `KnowledgeGraphEmbeddingConfiguration`): opt-in, default False, no-op without a write-capable client. Eliminates silent background writes.
- Partial fallback: Obtain the concept_ids that are missing in `omo_graph.extensions.emb.semantic_similarity` and only calculate new embeddings for these so they can be stored in the DB at runtime and afterwards correctly queried. Only active as fallback if `compute_missing_embeddings=True`.